### PR TITLE
Fix link to self-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A [Matrix](https://matrix.org/) bot to monitor and respond to investment scam sp
 
 ## Inviting the bot
 
-You can use my instance: `@anti-spam:matrix.org`, or [self-host](https://github.com/jjj333-p/spam-police#inviting-the-bot) your own!
+You can use my instance: `@anti-spam:matrix.org`, or [self-host](https://github.com/jjj333-p/spam-police#self-hosting) your own!
 
 To invite it, you can run the command below in [`#anti-scam-cmds:matrix.org`](https://matrix.to#anti-scam-cmds:matrix.org).
 ```matrix


### PR DESCRIPTION
Didn't fully check #22, it previously was linking to "Inviting the bot", now with this PR, it is linked to "Self-hosting".

