### PR TITLE
Stringify authorized-users

### DIFF
--- a/examples/login.yaml
+++ b/examples/login.yaml
@@ -18,6 +18,6 @@ command-room: '!dSGCuhsxXDDJxhJxJH:matrix.org'
 # Authorized Users
 # Users who can run admin commands on the bot (Restarting, blacklist, etc.)
 authorized-users:
-  - @erin:matrix.org
-  - @carlos:example.com
-  - @bob:example.org
+  - '@erin:matrix.org'
+  - '@carlos:example.com'
+  - '@bob:example.org'


### PR DESCRIPTION
Stringify the objects in authorized-users because Matrix usernames contain YAML special characters.