### PR TITLE
Remove whitespace in `index.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ client.on("room.event", async (roomId, event) => {
 
     //fetch the handler for that event type
     let handler = eventhandlers.get(event["type"])
-    
+
     //if there is a handler for that event, run it.
     if (handler) handler.run(client, roomId, event, mxid, displayname, banlist)
 


### PR DESCRIPTION
This PR removes whitespace in [`index.js:65`](https://github.com/jjj333-p/spam-police/blob/3e65741a9231ced15f3d76ce79cb9289c4045a32/index.js#L65).