### PR TITLE
Fix blockquote issue in the +uptime command

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -96,7 +96,7 @@ class message {
             let rMinutes = minutes - (hours*60)
 
             //send the uptime to the room
-            client.sendText(roomId, ("> " + seconds + "\n" + hours + " hours, " + rMinutes + " minutes, and " + Math.floor(rSeconds) + " seconds."))
+            client.sendHtmlText(roomId, ("<blockquote>\n<p>" + seconds + "</p>\n</blockquote>\n<p>" + hours + " hours, " + rMinutes + " minutes, and " + Math.floor(rSeconds) + " seconds.</p>"))
 
         //join cmd 
         } else if (scannableContent.startsWith("+join")) {


### PR DESCRIPTION
This PR fixes a bug where blockquotes weren't working in the `+uptime` command , with HTML.

<details><summary>Before:</summary>
<p>
> 568.667100153

0 hours, 9 minutes, and 28 seconds.
</p>
</details>

<details><summary>After:</summary>
<p>
<blockquote>568.667100153</blockquote>

0 hours, 9 minutes, and 28 seconds.
</p>
</details> 